### PR TITLE
Update custom top bar link active state

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -454,3 +454,6 @@
   margin-left: 15px;
   white-space: nowrap;
 }
+.top-bar__inner a:focus {
+  color: #0b0c0c;
+}


### PR DESCRIPTION
The existing CSS did not have an accessible active state, so this adds it and changes the text black so it can be read in front of the yellow highlight.